### PR TITLE
added base_network class

### DIFF
--- a/networks/base_network.py
+++ b/networks/base_network.py
@@ -1,0 +1,46 @@
+import tensorflow as tf
+import os
+
+
+class BaseNetwork:
+
+    def __init__(self):
+        '''Defines self.graph as an empty tensorflow graph'''
+        self.graph = tf.Graph()
+
+
+    def initialize_session(self):
+        '''Defines self.sess and initialize the variables'''
+        session_conf = tf.ConfigProto(
+            allow_soft_placement = True,
+            log_device_placement = False)
+
+        self.session = tf.Session(config = session_conf, graph=self.graph)
+
+        with self.graph.as_default():
+            self.init = tf.global_variables_initializer()
+            self.saver = tf.train.Saver()
+
+        self.session.run(self.init)
+
+
+    def save_model(self, output_dir):
+        '''Save the network graph and weights to disk'''
+        if not output_dir:
+            raise ValueError('You have to specify a valid output directory for DeepAgent.save_model')
+
+        if not os.path.exists(output_dir):
+            # if provided output_dir does not already exists, create it
+            os.mkdir(output_dir)
+
+        self.saver.save(self.session, './' + output_dir + '/')
+
+
+    def load_model(self, saved_model_dir):
+        '''Initialize a new tensorflow graph and session loading network and weights from a saved model'''
+        self.graph = tf.Graph()
+        with self.graph.as_default():
+            tf.train.import_meta_graph('./' + saved_model_dir + '/.meta')
+
+        self.initialize_session()
+        self.saver.restore(self.session, './' + saved_model_dir + '/')

--- a/networks/base_network.py
+++ b/networks/base_network.py
@@ -38,6 +38,7 @@ class BaseNetwork:
 
     def load_model(self, saved_model_dir):
         '''Initialize a new tensorflow graph and session loading network and weights from a saved model'''
+        saved_model_dir = saved_model_dir.rstrip('/')
         self.graph = tf.Graph()
         with self.graph.as_default():
             tf.train.import_meta_graph('./' + saved_model_dir + '/.meta')

--- a/networks/dqn.py
+++ b/networks/dqn.py
@@ -1,7 +1,11 @@
+import sys, os
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
 import numpy as np
 import tensorflow as tf
-import random, os, shutil
+import random
 
+from networks.base_network import BaseNetwork
 
 class ReplayMemory:
 
@@ -40,9 +44,11 @@ class ReplayMemory:
         return min(self.capacity, self.memory_counter)
 
 
-class DQN:
+class DQN(BaseNetwork):
 
     def __init__(self, n_actions, n_features, learning_rate = 1e-3, discount = 0.85):
+        # initialize base class
+        super().__init__()
 
         # network parameters
         self.n_features = n_features
@@ -68,7 +74,6 @@ class DQN:
 
     def create_network(self):
 
-        self.graph = tf.Graph()
         with self.graph.as_default():
 
             # input placeholders
@@ -176,35 +181,4 @@ class DQN:
 
         self.learn_step_counter += 1
 
-
-    def initialize_session(self):
-        '''Defines self.sess and initialize the variables'''
-        session_conf = tf.ConfigProto(
-            allow_soft_placement = True,
-            log_device_placement = False)
-
-        self.session = tf.Session(config = session_conf, graph=self.graph)
-
-        with self.graph.as_default():
-            self.init = tf.global_variables_initializer()
-            self.saver = tf.train.Saver()
-
-        self.session.run(self.init)
-
-
-    def save_model(self, output_dir):
-        '''Save the network graph and weights to disk'''
-        if not output_dir:
-            raise ValueError('You have to specify a valid output directory for DeepAgent.save_model')
-
-        if not os.path.exists(output_dir):
-            # if provided output_dir does not already exists, create it
-            os.mkdir(output_dir)
-
-        self.saver.save(self.session, "./" + output_dir + '/')
-
-
-    def load_model(self, saved_model_dir):
-        '''Initialize a new tensorflow session loading network and weights from a saved model'''
-        self.saver.restore(self.session, "./" + saved_model_dir + '/')
 

--- a/networks/drqn.py
+++ b/networks/drqn.py
@@ -1,6 +1,10 @@
+import sys, os
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
 import numpy as np
 import tensorflow as tf
-import random, os, shutil
+
+from networks.base_network import BaseNetwork
 
 
 class ReplayMemory:
@@ -46,9 +50,11 @@ class ReplayMemory:
         return min(self.capacity, self.memory_counter)
 
 
-class DRQN:
+class DRQN(BaseNetwork):
 
     def __init__(self, n_actions, n_features, learning_rate = 1e-3, discount = 0.85):
+        # initialize base class
+        super().__init__()
 
         # network parameters
         self.n_features = n_features
@@ -79,7 +85,6 @@ class DRQN:
 
     def create_network(self):
 
-        self.graph = tf.Graph()
         with self.graph.as_default():
             # input placeholders
             self.s = tf.placeholder(tf.float32, [None, self.n_features], name='states')  # input State
@@ -207,37 +212,3 @@ class DRQN:
             #print("Loss: ", loss)
 
         self.learn_step_counter += 1
-
-
-
-    def initialize_session(self):
-        '''Defines self.sess and initialize the variables'''
-        session_conf = tf.ConfigProto(
-            allow_soft_placement = True,
-            log_device_placement = False)
-
-        self.session = tf.Session(config = session_conf, graph=self.graph)
-
-        with self.graph.as_default():
-            self.init = tf.global_variables_initializer()
-            self.saver = tf.train.Saver()
-
-        self.session.run(self.init)
-
-
-    def save_model(self, output_dir):
-        '''Save the network graph and weights to disk'''
-        if not output_dir:
-            raise ValueError('You have to specify a valid output directory for DeepAgent.save_model')
-
-        if not os.path.exists(output_dir):
-            # if provided output_dir does not already exists, create it
-            os.mkdir(output_dir)
-
-        self.saver.save(self.session, "./" + output_dir + '/')
-
-
-    def load_model(self, saved_model_dir):
-        '''Initialize a new tensorflow session loading network and weights from a saved model'''
-        self.saver.restore(self.session, "./" + saved_model_dir + '/')
-


### PR DESCRIPTION
Now DQN and DRQN inherits from a BaseNetwork class which contains basic methods valid for every tensorflow network.
Simplify changes to these utilities as they have to be done only in 1 place.

Bug fix load_model method:
now it does not require that the graph that you are loading has the same structure as the current one.