### PR TITLE
small fixes to use loaded model

### DIFF
--- a/evaluate.py
+++ b/evaluate.py
@@ -42,7 +42,7 @@ def main(argv=None):
 
     # agent to be evaluated is RandomAgent or QAgent if a model is provided
     if FLAGS.model_dir:
-        eval_agent = QAgent()
+        eval_agent = QAgent(network=FLAGS.network)
         eval_agent.load_model(FLAGS.model_dir)
         eval_agent.make_greedy()
     else:

--- a/networks/drqn.py
+++ b/networks/drqn.py
@@ -91,7 +91,7 @@ class DRQN(BaseNetwork):
             self.s_ = tf.placeholder(tf.float32, [None, self.n_features], name='states_')  # input Next State
             self.r = tf.placeholder(tf.float32, [None, ], name='rewards')  # input Reward
             self.a = tf.placeholder(tf.int32, [None, ], name='actions')  # input Action
-            self.events_length = tf.placeholder(dtype=tf.int32)
+            self.events_length = tf.placeholder(tf.int32, None, name='events_length')
             w_initializer, b_initializer = tf.random_normal_initializer(0., 0.3), tf.constant_initializer(0.1)
 
             # evaluation network
@@ -99,7 +99,6 @@ class DRQN(BaseNetwork):
 
                 e1 = tf.layers.dense(self.s, 128, tf.nn.relu, kernel_initializer=w_initializer,
                             bias_initializer=b_initializer, name= 'e1')
-
 
                 rnn_s = tf.reshape(tf.contrib.slim.flatten(e1),[-1,self.events_length, 128])
                 rnn_multi_cells_e = tf.contrib.rnn.MultiRNNCell([tf.nn.rnn_cell.LSTMCell(layer_size) for layer_size in self.lstm_layers])
@@ -170,11 +169,12 @@ class DRQN(BaseNetwork):
             ''' Compute q table for current state'''
 
             states_op = self.session.graph.get_operation_by_name(f"states").outputs[0]
+            events_op = self.session.graph.get_operation_by_name(f"events_length").outputs[0]
             #argmax_op = self.session.graph.get_operation_by_name("predictions/argmax").outputs[0]
             q_op = self.session.graph.get_operation_by_name(f"eval_net/q/BiasAdd").outputs[0]
 
             input_state = np.expand_dims(state, axis=0)
-            q = self.session.run([q_op], feed_dict={states_op: input_state, self.events_length : 1})
+            q = self.session.run([q_op], feed_dict={states_op: input_state, events_op : 1})
 
             return q[0][0]
 

--- a/self_train.py
+++ b/self_train.py
@@ -137,8 +137,15 @@ def main(argv=None):
 
     # Initialize agent
     agent = QAgent(
-        FLAGS.epsilon, FLAGS.epsilon_increment, FLAGS.epsilon_max, FLAGS.discount,
-        FLAGS.learning_rate)
+        FLAGS.epsilon,
+        FLAGS.epsilon_increment,
+        FLAGS.epsilon_max,
+        FLAGS.discount,
+        FLAGS.network,
+        FLAGS.layers,
+        FLAGS.learning_rate,
+        FLAGS.replace_target_iter,
+        FLAGS.batch_size)
 
     # Training
     best_total_wins = self_train(game, agent,
@@ -168,6 +175,7 @@ if __name__ == '__main__':
     # Evaluation parameters
     parser.add_argument("--evaluate_every", default=1000, help="Evaluate model after this many epochs", type=int)
     parser.add_argument("--num_evaluations", default=500, help="Number of evaluation games against each type of opponent for each test", type=int)
+    parser.add_argument("--evaluation_dir", default="evaluation_dir", help="Directory where plots are stored", type=str)
 
     # State parameters
     parser.add_argument("--cards_order", default=CardsOrder.APPEND, choices=[CardsOrder.APPEND, CardsOrder.REPLACE, CardsOrder.VALUE], help="Where a drawn card is put in the hand")


### PR DESCRIPTION
After loading a model, you can't use anymore self.events_lenght or similar variables since they are storing old versions of the tensors.

Now self_train works properly.
Before I tested it only with dqn where this error was not present.

Plus small fixes