### PR TITLE
Fix drqn

### DIFF
--- a/agents/ai_agent.py
+++ b/agents/ai_agent.py
@@ -10,7 +10,7 @@ class AIAgent:
         self.name = 'AIAgent'
 
 
-    def observe(self, game, player, deck):
+    def observe(self, game, player):
         ''' store information about the state of the game to be used in the decisional process'''
         self.hand = player.hand
         self.points = player.points

--- a/agents/human_agent.py
+++ b/agents/human_agent.py
@@ -6,7 +6,7 @@ class HumanAgent:
     def __init__(self):
         self.name = 'HumanAgent'
 
-    def observe(self, game, player, deck):
+    def observe(self, game, player):
         self.hand = player.hand
         self.briscola = game.briscola
         self.played_cards = game.played_cards
@@ -34,4 +34,10 @@ class HumanAgent:
 
 
     def update(self, reward):
+        pass
+
+    def make_greedy(self):
+        pass
+
+    def restore_epsilon(self):
         pass

--- a/agents/q_agent.py
+++ b/agents/q_agent.py
@@ -23,9 +23,9 @@ class QAgent():
         self.epsilon_increment = epsilon_increment
 
         self.last_state = None
-        self.state = None
         self.action = None
         self.reward = None
+        self.state = None
 
         # create q learning algorithm
         if network == NetworkTypes.DQN:
@@ -36,8 +36,7 @@ class QAgent():
             raise ValueError("Not implemented type of network passed to QAgent")
 
 
-
-    def observe(self, game, player, deck):
+    def observe(self, game, player):
         ''' create an encoded state representation of the game to be fed into the neural network
             the state is composed of 5 cards (3 in hand, 1 played card on table, 1 briscola)
             each card is array of size 14, separating one hot encoded number and seed i.e. [number_one_hot, seed_one_hot]
@@ -49,6 +48,7 @@ class QAgent():
 
         state = np.zeros(self.n_features)
         # add hand to state
+
         for i, card in enumerate(player.hand):
             number_index = i * 14 + card.number
             state[number_index] = 1
@@ -114,10 +114,16 @@ class QAgent():
         else:
             self.reward = reward
         '''
+
         # update last reward
         self.reward = reward
+
         # update epsilon grediness
-        self.epsilon = self.epsilon + self.epsilon_increment if self.epsilon < self.epsilon_max else self.epsilon_max
+        if self.epsilon < self.epsilon_max:
+            self.epsilon += self.epsilon_increment
+            if self.epsilon >= self.epsilon_max:
+                self.epsilon = self.epsilon_max
+                print("Epsilon max: ", self.epsilon_max, " reached!")
 
         self.q_learning.learn(self.last_state, self.action, self.reward, self.state)
 

--- a/agents/q_agent.py
+++ b/agents/q_agent.py
@@ -45,7 +45,7 @@ class QAgent():
         '''
 
         # Reordering the player hand in descending order (high value -> low value)
-        game.reorder_hand(player.id)
+        #game.reorder_hand(player.id)
 
         state = np.zeros(self.n_features)
         # add hand to state

--- a/environment.py
+++ b/environment.py
@@ -351,7 +351,7 @@ def play_episode(game, agents, train=True):
             player = game.players[player_id]
             agent = agents[player_id]
             # agent observes state before acting
-            agent.observe(game, player, game.deck)
+            agent.observe(game, player)
             available_actions = game.get_player_actions(player_id)
             action = agent.select_action(available_actions)
 
@@ -364,7 +364,7 @@ def play_episode(game, agents, train=True):
                 player = game.players[player_id]
                 agent = agents[player_id]
                 # agent observes new state after acting
-                agent.observe(game, player, game.deck)
+                agent.observe(game, player)
 
                 reward = rewards[i]
                 agent.update(reward)

--- a/human_vs_ai.py
+++ b/human_vs_ai.py
@@ -20,7 +20,7 @@ def main(argv=None):
     agents.append(HumanAgent())
 
     if FLAGS.model_dir:
-        agent = QAgent()
+        agent = QAgent(network=FLAGS.network)
         agent.load_model(FLAGS.model_dir)
         agent.make_greedy()
         agents.append(agent)

--- a/human_vs_ai.py
+++ b/human_vs_ai.py
@@ -7,6 +7,7 @@ from agents.human_agent import HumanAgent
 
 import environment as brisc
 from utils import BriscolaLogger
+from utils import NetworkTypes
 
 def main(argv=None):
 
@@ -27,7 +28,7 @@ def main(argv=None):
         agent = AIAgent()
         agents.append(agent)
 
-    brisc.play_episode(game, agents)
+    brisc.play_episode(game, agents, train=False)
 
 
 

--- a/networks/dqn.py
+++ b/networks/dqn.py
@@ -18,7 +18,7 @@ class ReplayMemory:
 
     def push(self, s, a, r, s_):
         # stacks together all states element
-        event = np.hstack((s, [a, r], s_))
+        event = np.hstack((s, a, r, s_))
         # get the index where to insert the event
         index = self.memory_counter % self.capacity
         self.memory[index, :] = event
@@ -135,19 +135,20 @@ class DQN(BaseNetwork):
 
 
     def get_q_table(self, state):
-            ''' Compute q table for current state'''
+        ''' Compute q table for current state'''
 
-            states_op = self.session.graph.get_operation_by_name("states").outputs[0]
-            #argmax_op = self.session.graph.get_operation_by_name("predictions/argmax").outputs[0]
-            q_op = self.session.graph.get_operation_by_name("eval_net/q/BiasAdd").outputs[0]
+        states_op = self.session.graph.get_operation_by_name("states").outputs[0]
+        #argmax_op = self.session.graph.get_operation_by_name("predictions/argmax").outputs[0]
+        q_op = self.session.graph.get_operation_by_name("eval_net/q/BiasAdd").outputs[0]
 
-            input_state = np.expand_dims(state, axis=0)
-            q = self.session.run([q_op], feed_dict={states_op: input_state})
+        input_state = np.expand_dims(state, axis=0)
+        q = self.session.run([q_op], feed_dict={states_op: input_state})
 
-            return q[0][0]
+        return q[0][0]
 
 
     def learn(self, last_state, action, reward, state):
+        ''' Sample from memory and train neural network on a batch of experiences '''
 
         # I have a full event [s, a, r, s_], push it into replay memory
         self.replay_memory.push(last_state, action, reward, state)

--- a/networks/drqn.py
+++ b/networks/drqn.py
@@ -11,9 +11,11 @@ class ReplayMemory:
 
     def __init__(self, capacity, n_features):
 
+        # initialize zero memory, each sample in memory has size [s + a + r + s_ + t]
+        # where s and s_ are 1xn_features, a r t are scalar
+
         self.capacity = capacity
         self.event_size = n_features * 2 + 2
-        # initialize zero memory, each sample in memory has size [s + a + r + s_]
         self.memory = np.zeros((self.capacity, 20, self.event_size))
         self.memory_counter = 0
 
@@ -22,7 +24,7 @@ class ReplayMemory:
         index = self.memory_counter % self.capacity
         self.memory[index, :] = episode
 
-        # increment memory_counter avoiding overflow
+        # increment memory_counter avoiding overflow (I only need to keep track if memory is full or not)
         self.memory_counter += 1
         if self.memory_counter == (self.capacity * 2):
             self.memory_counter = self.capacity
@@ -65,6 +67,11 @@ class DRQN(BaseNetwork):
         self.trace_length = 5
         self.replace_target_iter = replace_target_iter
 
+        # update parameters
+        self.learn_iter = 0
+        self.update_each = 8
+        self.update_after = 5000
+
         # layers parameters
         self.lstm_layers = layers
 
@@ -105,8 +112,7 @@ class DRQN(BaseNetwork):
 
                 rnn_output_e, _ = tf.nn.dynamic_rnn(
                     rnn_multi_cells_e, rnn_s, dtype=tf.float32)
-                rnn_output_e = tf.reshape(rnn_output_e,shape=[-1, self.lstm_layers[-1]])
-
+                rnn_output_e = rnn_output_e[:, -1, :]
 
                 e2 = tf.layers.dense(rnn_output_e, 32, kernel_initializer=w_initializer,
                                         bias_initializer=b_initializer, name='e2')
@@ -126,9 +132,7 @@ class DRQN(BaseNetwork):
 
                 rnn_output_t, _ = tf.nn.dynamic_rnn(
                     multi_cells_t, rnn_s_, dtype=tf.float32)
-                rnn_output_t = tf.reshape(rnn_output_t,shape=[-1, self.lstm_layers[-1]])
-
-
+                rnn_output_t = rnn_output_t[:, -1, :]
 
                 t2 = tf.layers.dense(rnn_output_t, 32, kernel_initializer=w_initializer,
                                         bias_initializer=b_initializer, name='t2')
@@ -141,12 +145,16 @@ class DRQN(BaseNetwork):
                 self.argmax_action = tf.argmax(self.q, 1, output_type=tf.int32, name='argmax')
             with tf.variable_scope('q_target'):
                 # discounted reward on the target network
-                q_target = self.r + self.gamma * tf.reduce_max(self.q_next, axis=1, name='q_target')
+                rewards_history = tf.reshape(self.r, [-1,self.events_length])
+                current_rewards = rewards_history[:, -1]
+                q_target = current_rewards + self.gamma * tf.reduce_max(self.q_next, axis=1, name='q_target')
                 # stop gradient to avoid updating target network
                 self.q_target = tf.stop_gradient(q_target)
             with tf.variable_scope('q_wrt_a'):
                 # q value of chosen action
-                a_indices = tf.stack([tf.range(tf.shape(self.a)[0], dtype=tf.int32), self.a], axis=1)
+                actions_history = tf.reshape(self.a, [-1,self.events_length])
+                current_actions = actions_history[:, -1]
+                a_indices = tf.stack([tf.range(tf.shape(current_actions)[0], dtype=tf.int32), current_actions], axis=1)
                 self.q_wrt_a = tf.gather_nd(params=self.q, indices=a_indices)
             with tf.variable_scope('loss'):
                 # loss computed as difference between predicted q[a] and (current_reward + discount * q_target[best_future_action])
@@ -186,20 +194,32 @@ class DRQN(BaseNetwork):
 
         return q[0][-1]
 
+    def store(self, last_state, action, reward, state):
+        ''' Store the current experience in memory '''
 
-    def learn(self, last_state, action, reward, state):
-
-        state_vector = np.hstack((last_state, [action, reward], state))
+        state_vector = np.hstack((last_state, action, reward, state))
         self.last_episode.append(state_vector)
 
+        # if terminal state reached, I can store the full episode in memory
         # HACK for check end episode
         if len(self.last_episode) == 20:
             self.replay_memory.push(self.last_episode)
             self.last_episode = []
 
+    def learn(self, last_state, action, reward, state):
+        ''' Sample from memory and train neural network on a batch of experiences '''
+
+        self.store(last_state, action, reward, state)
+
+        # check if it's time to update the network
+        self.learn_iter += 1
+        if self.learn_iter % self.update_each != 0 or self.learn_iter < self.update_after:
+            return
+
         if self.replay_memory.size() < self.batch_size:
             # there are not enough samples for a training step in the replay memory
             return
+
         # get a batch of samples from replay memory
         batch_memory = self.replay_memory.sample(self.batch_size, self.trace_length)
 

--- a/train.py
+++ b/train.py
@@ -83,7 +83,7 @@ if __name__ == '__main__':
 
     # Reinforcement Learning parameters
     parser.add_argument("--epsilon", default=0, help="How likely is the agent to choose the best reward action over a random one", type=float)
-    parser.add_argument("--epsilon_increment", default=5e-5, help="How much epsilon is increased after each action taken up to epsilon_max", type=float)
+    parser.add_argument("--epsilon_increment", default=1e-5, help="How much epsilon is increased after each action taken up to epsilon_max", type=float)
     parser.add_argument("--epsilon_max", default=0.85, help="The maximum value for the incremented epsilon", type=float)
     parser.add_argument("--discount", default=0.85, help="How much a reward is discounted after each step", type=float)
 


### PR DESCRIPTION
# DRQN CHANGES
### BEFORE:
The get_q_table method (used for selecting next action) was using only the last state as input, even if this is a recurrent neural network.
On the other hand the learn method was using batches of elements for training where each element was a sequence of episodes.
The recurrent layers were working in this way:
- the input is [batch_dim x events_length x num_features] (during get_q_table, both batch and event_length are 1)
- The output of the reccurrent layer has the same shape, so it's reshaped to become a 2D array [(batch_dim*events_length) x num_features].
- This output goes to last fully connected layer to get some q_tables (number equal to events_length).

Only the last q_table, i.e. the one related to the most recent state was used to choose next action. 

Similarly rewards and actions have a shape [batch_dim x events_length x 1] and we were using the whole array to compute the loss.

This means that if you provide 5 consecutive states (events_length =5 and assume batch_dim = 1 for simplicity) you were computing 5 q_tables and comparing all of them with the 5 rewards in order to get the loss.


### NOW:

the get_q_table method uses all the last available states to compute the table, the number of states used is at max self.events_length.
- added `self.epoch_history = []` variable. this one stores [state] for all the steps in the current episode
Note that this information is also in self.last_episode... It's possible to use only one variable?
After the LSTM layer, only the output from the "last state" is used to predict q_table, so we have only 1 q_table. This makes sense as it's how RNN are used for classification, where only 1 value is of interest.
` rnn_output_e = rnn_output_e[:, -1, :]` 
Note that is not necessary anymore to reshape this thing as it's already 2D [batch_dim x num_features].

Similarly also the loss computation is updated.
If I provide 5 consecutive states to the network, its only because I want to give some context in order to use LSTM and get more accurate q_table.
What I want to predict is always the reward from the last step, so I can drop all the intermediate ones.

```
rewards_history = tf.reshape(self.r, [-1,self.events_length])
current_rewards = rewards_history[:, -1]
```


# GENERAL SMALL CHANGES
 - `ai_agent.py`, `human_agent.py`, `q_agent.py`, `environment.py`: now observe function does not  take deck as argument anymore.. if it's needed, you can get it as game.deck
- `q_agent.py` written epsilon update in a different way, to easy print something when epsilon_max is reached (using epsilon_increment 1e-5 it happens after 5k epochs more or less)