### PR TITLE
Rl updates

### DIFF
--- a/agents/q_agent.py
+++ b/agents/q_agent.py
@@ -27,6 +27,7 @@ class QAgent():
         self.reward = None
         self.state = None
         self.terminal = None
+        self.network = network
 
         # create q learning algorithm
         if network == NetworkTypes.DQN:

--- a/agents/q_agent.py
+++ b/agents/q_agent.py
@@ -26,6 +26,7 @@ class QAgent():
         self.action = None
         self.reward = None
         self.state = None
+        self.terminal = None
 
         # create q learning algorithm
         if network == NetworkTypes.DQN:
@@ -73,6 +74,7 @@ class QAgent():
 
         self.last_state = self.state
         self.state = state
+        self.terminal = int(game.check_end_game())
 
 
     def select_action(self, available_actions):
@@ -125,7 +127,7 @@ class QAgent():
                 self.epsilon = self.epsilon_max
                 print("Epsilon max: ", self.epsilon_max, " reached!")
 
-        self.q_learning.learn(self.last_state, self.action, self.reward, self.state)
+        self.q_learning.learn(self.last_state, self.action, self.reward, self.state, self.terminal)
 
 
     def save_model(self, output_dir):

--- a/agents/q_agent.py
+++ b/agents/q_agent.py
@@ -75,8 +75,6 @@ class QAgent():
         self.last_state = self.state
         self.state = state
         self.terminal = int(game.check_end_game())
-        if (self.terminal):
-            print("TERMINAL")
 
 
     def select_action(self, available_actions):

--- a/agents/q_agent.py
+++ b/agents/q_agent.py
@@ -75,6 +75,8 @@ class QAgent():
         self.last_state = self.state
         self.state = state
         self.terminal = int(game.check_end_game())
+        if (self.terminal):
+            print("TERMINAL")
 
 
     def select_action(self, available_actions):

--- a/environment.py
+++ b/environment.py
@@ -368,4 +368,14 @@ def play_episode(game, agents, train=True):
         # update the environment
         game.draw_step()
 
+    # TODO: this is ugly
+    # observe terminal state
+    for i, player_id in enumerate(players_order):
+        player = game.players[player_id]
+        agent = agents[player_id]
+        # agent observes state before acting
+        agent.observe(game, player)
+        if train and rewards:
+            agent.update(rewards[i])
+
     return game.end_game()

--- a/environment.py
+++ b/environment.py
@@ -185,6 +185,8 @@ class BriscolaGame:
         ''' each player, in order, tries to draw a card'''
         self.logger.PVP("----------- NEW TURN -----------")
 
+        self.played_cards = []
+
         for player_id in self.players_order:
             player = self.players[player_id]
 
@@ -285,7 +287,6 @@ class BriscolaGame:
         winner_player_id = winner_player.id
         winner_player.points += points
 
-        self.played_cards = []
         self.turn_player = winner_player_id
         self.players_order = self.get_players_order()
 

--- a/environment.py
+++ b/environment.py
@@ -343,32 +343,27 @@ def scoring(briscola_seed, card_0, card_1, keep_order=True):
 def play_episode(game, agents, train=True):
 
     game.reset()
+    rewards = []
     while not game.check_end_game():
 
         # action step
         players_order = game.get_players_order()
-        for player_id in players_order:
+        for i, player_id in enumerate(players_order):
 
             player = game.players[player_id]
             agent = agents[player_id]
             # agent observes state before acting
             agent.observe(game, player)
+
+            if train and rewards:
+                agent.update(rewards[i])
+
             available_actions = game.get_player_actions(player_id)
             action = agent.select_action(available_actions)
 
             game.play_step(action, player_id)
 
         rewards = game.get_rewards_from_step()
-        # update agents if training mode
-        if train:
-            for i, player_id in enumerate(players_order):
-                player = game.players[player_id]
-                agent = agents[player_id]
-                # agent observes new state after acting
-                agent.observe(game, player)
-
-                reward = rewards[i]
-                agent.update(reward)
 
         # update the environment
         game.draw_step()

--- a/networks/dqn.py
+++ b/networks/dqn.py
@@ -69,14 +69,13 @@ class DQN(BaseNetwork):
 
         # init vars
         self.learn_step_counter = 0
-        self.wrong_move = False
-        self.session = None
 
         # create replay memroy
         capacity = 10000
         self.replay_memory = ReplayMemory(capacity, self.n_features)
 
         # create network
+        self.session = None
         self.create_network()
         self.initialize_session()
 
@@ -194,7 +193,7 @@ class DQN(BaseNetwork):
         # check if it's time to copy the target network into the evaluation network
         if self.learn_step_counter % self.replace_target_iter == 0:
             self.session.run(self.target_replace_op)
-            print("Loss: ", loss)
+            #print("Loss: ", loss)
 
         self.learn_step_counter += 1
 

--- a/networks/dqn.py
+++ b/networks/dqn.py
@@ -60,15 +60,12 @@ class DQN(BaseNetwork):
         self.replace_target_iter = replace_target_iter
 
         # update parameters
-        self.learn_iter = 0
+        self.learn_step_counter = 0
         self.update_each = 1
         self.update_after = 5000
 
         # layers parameters
         self.layers = layers
-
-        # init vars
-        self.learn_step_counter = 0
 
         # create replay memroy
         capacity = 10000
@@ -168,8 +165,8 @@ class DQN(BaseNetwork):
         self.store(last_state, action, reward, state, terminal)
 
         # check if it's time to update the network
-        self.learn_iter += 1
-        if self.learn_iter % self.update_each != 0 or self.learn_iter < self.update_after:
+        self.learn_step_counter += 1
+        if self.learn_step_counter % self.update_each != 0 or self.learn_step_counter < self.update_after:
             return
 
         if self.replay_memory.size() < self.batch_size:
@@ -194,7 +191,5 @@ class DQN(BaseNetwork):
         if self.learn_step_counter % self.replace_target_iter == 0:
             self.session.run(self.target_replace_op)
             #print("Loss: ", loss)
-
-        self.learn_step_counter += 1
 
 

--- a/networks/dqn.py
+++ b/networks/dqn.py
@@ -11,19 +11,20 @@ class ReplayMemory:
 
     def __init__(self, capacity, n_features):
 
+        # initialize zero memory, each sample in memory has size [s + a + r + s_ + t]
+        # where s and s_ are 1xn_features, a r t are scalar
+
         self.capacity = capacity
-        # initialize zero memory, each sample in memory has size [s + a + r + s_]
-        self.memory = np.zeros((self.capacity, n_features * 2 + 2))
+        self.event_size = n_features * 2 + 3
+        self.memory = np.zeros((self.capacity, self.event_size))
         self.memory_counter = 0
 
-    def push(self, s, a, r, s_):
-        # stacks together all states element
-        event = np.hstack((s, a, r, s_))
+    def push(self, item):
         # get the index where to insert the event
         index = self.memory_counter % self.capacity
-        self.memory[index, :] = event
+        self.memory[index, :] = item
 
-        # increment memory_counter avoiding overflow
+        # increment memory_counter avoiding overflow (I only need to keep track if memory is full or not)
         self.memory_counter += 1
         if self.memory_counter == (self.capacity * 2):
             self.memory_counter = self.capacity
@@ -58,6 +59,12 @@ class DQN(BaseNetwork):
         self.batch_size = batch_size
         self.replace_target_iter = replace_target_iter
 
+        # update parameters
+        self.learn_iter = 0
+        self.update_each = 1
+        self.update_after = 5000
+
+        # layers parameters
         self.layers = layers
 
         # init vars
@@ -83,6 +90,7 @@ class DQN(BaseNetwork):
             self.a = tf.placeholder(tf.int32, [None, ], name='actions')  # input Action
             self.r = tf.placeholder(tf.float32, [None, ], name='rewards')  # input Reward
             self.s_ = tf.placeholder(tf.float32, [None, self.n_features], name='states_')  # input Next State
+            self.terminal = tf.placeholder(tf.float32, [None, ], name='terminal') # indication if next state is terminal
 
             w_initializer, b_initializer = tf.random_normal_initializer(0., 0.3), tf.constant_initializer(0.1)
 
@@ -111,7 +119,7 @@ class DQN(BaseNetwork):
                 self.argmax_action = tf.argmax(self.q, 1, output_type=tf.int32, name="argmax")
             with tf.variable_scope('q_target'):
                 # discounted reward on the target network
-                q_target = self.r + self.gamma * tf.reduce_max(self.q_next, axis=1, name='q_target')
+                q_target = self.r + (1. - self.terminal) * self.gamma * tf.reduce_max(self.q_next, axis=1, name='q_target')
                 # stop gradient to avoid updating target network
                 self.q_target = tf.stop_gradient(q_target)
             with tf.variable_scope('q_wrt_a'):
@@ -146,16 +154,29 @@ class DQN(BaseNetwork):
 
         return q[0][0]
 
+    def store(self, last_state, action, reward, state, terminal):
+        ''' Store the current experience in memory '''
 
-    def learn(self, last_state, action, reward, state):
+        # stacks together all states element
+        state_vector = np.hstack((last_state, action, reward, state, terminal))
+
+        self.replay_memory.push(state_vector)
+
+
+    def learn(self, last_state, action, reward, state, terminal):
         ''' Sample from memory and train neural network on a batch of experiences '''
 
-        # I have a full event [s, a, r, s_], push it into replay memory
-        self.replay_memory.push(last_state, action, reward, state)
+        self.store(last_state, action, reward, state, terminal)
+
+        # check if it's time to update the network
+        self.learn_iter += 1
+        if self.learn_iter % self.update_each != 0 or self.learn_iter < self.update_after:
+            return
 
         if self.replay_memory.size() < self.batch_size:
             # there are not enough samples for a training step in the replay memory
             return
+
         # get a batch of samples from replay memory
         batch_memory = self.replay_memory.sample(self.batch_size)
 
@@ -166,7 +187,8 @@ class DQN(BaseNetwork):
                 self.s: batch_memory[:, : self.n_features],
                 self.a: batch_memory[:, self.n_features],
                 self.r: batch_memory[:, self.n_features + 1],
-                self.s_: batch_memory[:, -self.n_features:],
+                self.s_: batch_memory[:, -self.n_features-1:-1],
+                self.terminal: batch_memory[:, -1],
             })
 
         # check if it's time to copy the target network into the evaluation network

--- a/networks/drqn.py
+++ b/networks/drqn.py
@@ -78,7 +78,7 @@ class DRQN(BaseNetwork):
 
         # init vars
         self.learn_step_counter = 0
-        self.session = None
+        self.epoch_history = []
 
         # TODO: use only 1 variable
         # store the sequence of states in an episode
@@ -91,6 +91,7 @@ class DRQN(BaseNetwork):
         self.replay_memory = ReplayMemory(capacity, n_features)
 
         # create network
+        self.session = None
         self.create_network()
         self.initialize_session()
 

--- a/networks/drqn.py
+++ b/networks/drqn.py
@@ -71,7 +71,7 @@ class DRQN(BaseNetwork):
         # update parameters
         self.learn_step_counter = 0
         self.update_each = 8
-        self.update_after = 5000
+        self.update_after = 0
 
         # layers parameters
         self.lstm_layers = layers
@@ -207,7 +207,6 @@ class DRQN(BaseNetwork):
 
         # if terminal state reached, I can store the full episode in memory
         if terminal:
-            print("push")
             self.replay_memory.push(self.samples_history)
             self.samples_history = []
 
@@ -223,7 +222,6 @@ class DRQN(BaseNetwork):
         if self.replay_memory.size() < self.batch_size:
             # there are not enough samples for a training step in the replay memory
             return
-        print("update")
 
         # get a batch of samples from replay memory
         batch_memory = self.replay_memory.sample(self.batch_size, self.trace_length)

--- a/networks/drqn.py
+++ b/networks/drqn.py
@@ -11,18 +11,19 @@ class ReplayMemory:
 
     def __init__(self, capacity, n_features):
 
-        # initialize zero memory, each sample in memory has size [s + a + r + s_ + t]
+        # initialize zero memory, each sample in memory has size episode_length * [s + a + r + s_ + t]
         # where s and s_ are 1xn_features, a r t are scalar
 
         self.capacity = capacity
-        self.event_size = n_features * 2 + 2
-        self.memory = np.zeros((self.capacity, 20, self.event_size))
+        self.episode_length = 20
+        self.event_size = n_features * 2 + 3
+        self.memory = np.zeros((self.capacity, self.episode_length, self.event_size))
         self.memory_counter = 0
 
-    def push(self, episode):
+    def push(self, item):
         # get the index where to insert the episode
         index = self.memory_counter % self.capacity
-        self.memory[index, :] = episode
+        self.memory[index, :] = item
 
         # increment memory_counter avoiding overflow (I only need to keep track if memory is full or not)
         self.memory_counter += 1
@@ -84,7 +85,7 @@ class DRQN(BaseNetwork):
         self.states_history = []
         # store the sequence of training samples (s, a, r, s_) in an episode
         self.samples_history = []
-        
+
         # create replay memroy
         capacity = 2500
         self.replay_memory = ReplayMemory(capacity, n_features)
@@ -102,6 +103,7 @@ class DRQN(BaseNetwork):
             self.a = tf.placeholder(tf.int32, [None, ], name='actions')  # input Action
             self.r = tf.placeholder(tf.float32, [None, ], name='rewards')  # input Reward
             self.s_ = tf.placeholder(tf.float32, [None, self.n_features], name='states_')  # input Next State
+            self.terminal = tf.placeholder(tf.float32, [None, ], name='terminal') # indication if next state is terminal
             self.events_length = tf.placeholder(tf.int32, None, name='events_length')
             w_initializer, b_initializer = tf.random_normal_initializer(0., 0.3), tf.constant_initializer(0.1)
 
@@ -151,7 +153,9 @@ class DRQN(BaseNetwork):
                 # discounted reward on the target network
                 rewards_history = tf.reshape(self.r, [-1,self.events_length])
                 current_rewards = rewards_history[:, -1]
-                q_target = current_rewards + self.gamma * tf.reduce_max(self.q_next, axis=1, name='q_target')
+                terminal_history = tf.reshape(self.terminal, [-1,self.events_length])
+                current_terminals = terminal_history[:, -1]
+                q_target = current_rewards + (1. - current_terminals) * self.gamma * tf.reduce_max(self.q_next, axis=1, name='q_target')
                 # stop gradient to avoid updating target network
                 self.q_target = tf.stop_gradient(q_target)
             with tf.variable_scope('q_wrt_a'):
@@ -198,22 +202,21 @@ class DRQN(BaseNetwork):
 
         return q[0][-1]
 
-    def store(self, last_state, action, reward, state):
+    def store(self, last_state, action, reward, state, terminal):
         ''' Store the current experience in memory '''
 
-        state_vector = np.hstack((last_state, action, reward, state))
-        self.samples_history.append(state_vector)
+        state_vector = np.hstack((last_state, action, reward, state, terminal))
+        self.last_episode.append(state_vector)
 
         # if terminal state reached, I can store the full episode in memory
-        # HACK for check end episode
-        if len(self.samples_history) == 20:
-            self.replay_memory.push(self.samples_history)
-            self.samples_history = []
+        if terminal:
+            self.replay_memory.push(self.last_episode)
+            self.last_episode = []
 
-    def learn(self, last_state, action, reward, state):
+    def learn(self, last_state, action, reward, state, terminal):
         ''' Sample from memory and train neural network on a batch of experiences '''
 
-        self.store(last_state, action, reward, state)
+        self.store(last_state, action, reward, state, terminal)
 
         # check if it's time to update the network
         self.learn_iter += 1
@@ -234,7 +237,8 @@ class DRQN(BaseNetwork):
                 self.s: batch_memory[:, : self.n_features],
                 self.a: batch_memory[:, self.n_features],
                 self.r: batch_memory[:, self.n_features + 1],
-                self.s_: batch_memory[:, -self.n_features:],
+                self.s_: batch_memory[:, -self.n_features-1:-1],
+                self.terminal: batch_memory[:, -1],
                 self.events_length : self.trace_length,
             })
 


### PR DESCRIPTION


Fixed some "reference before assignment" errors

Updated states observation policy: now agents observe only before acting, to have a continuity in the states sequences.
An additional observe step is performed once the game is ended.

Added placeholder for "terminal" boolean which is true when the next_state in (state, action, reward, next_state) is a terminal state.

